### PR TITLE
Standardize results format

### DIFF
--- a/process_data.sh
+++ b/process_data.sh
@@ -167,8 +167,6 @@ compute_snr_cnr(){
    num_slices=$((num_slices-1))
 
 
-   mkdir -p ${PATH_RESULTS}/SNR/${SUBJECT_SLASH_SESSION}
-   mkdir -p ${PATH_RESULTS}/CNR/${SUBJECT_SLASH_SESSION}
 
    # Calculate SNR/CNR for each slice
    for g in $(seq -w 0 ${num_slices}); do


### PR DESCRIPTION
Calculates the mean and median for CNR and SNR for the entire volume based on Issue #20 and outputs into a single CSV file in the results folder instead of separate CSV files for each subject. The script separates the navigated and standard outputs into different CSV files. 

Also included a statement that only calculates SNR and CNR for the slices where a GM mask exists - if there is no GM mask, there will be no CNR value or SNR_gm value for that slice, nor an accurate SNR_wm value. 